### PR TITLE
Ena mars receipt

### DIFF
--- a/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/controller/WebinIsaToXmlSubmissionController.java
+++ b/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/controller/WebinIsaToXmlSubmissionController.java
@@ -9,6 +9,8 @@ import com.elixir.biohackaton.ISAToSRA.model.Investigation;
 import com.elixir.biohackaton.ISAToSRA.model.IsaJson;
 import com.elixir.biohackaton.ISAToSRA.model.Study;
 import com.elixir.biohackaton.ISAToSRA.sra.service.*;
+import com.elixir.biohackaton.ISAToSRA.sra.model.MarsReceipt;
+import com.elixir.biohackaton.ISAToSRA.sra.model.Receipt;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -30,34 +32,42 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RestController
 public class WebinIsaToXmlSubmissionController {
-  @Autowired private BioSamplesAccessionsParser bioSamplesAccessionsParser;
+  @Autowired
+  private BioSamplesAccessionsParser bioSamplesAccessionsParser;
 
-  @Autowired private WebinStudyXmlCreator webinStudyXmlCreator;
+  @Autowired
+  private WebinStudyXmlCreator webinStudyXmlCreator;
 
-  @Autowired private WebinExperimentXmlCreator webinExperimentXmlCreator;
+  @Autowired
+  private WebinExperimentXmlCreator webinExperimentXmlCreator;
 
-  @Autowired private WebinProjectXmlCreator webinProjectXmlCreator;
+  @Autowired
+  private WebinProjectXmlCreator webinProjectXmlCreator;
 
-  @Autowired private WebinRunXmlCreator webinRunXmlCreator;
+  @Autowired
+  private WebinRunXmlCreator webinRunXmlCreator;
 
-  @Autowired private WebinHttpSubmissionService webinHttpSubmissionService;
+  @Autowired
+  private WebinHttpSubmissionService webinHttpSubmissionService;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  private ObjectMapper objectMapper;
 
-  @Autowired private ReceiptConversionService receiptConversionService;
+  @Autowired
+  private ReceiptConversionService receiptConversionService;
 
-  @ApiResponses(
-      value = {
-        @ApiResponse(responseCode = "200", description = "Ok"),
-        @ApiResponse(responseCode = "401", description = "Unauthorized"),
-        @ApiResponse(responseCode = "403", description = "Forbidden"),
-        @ApiResponse(responseCode = "400", description = "Bad request"),
-        @ApiResponse(responseCode = "408", description = "Request Timeout"),
-        @ApiResponse(responseCode = "415", description = "Unsupported media type")
-      })
-  @PostMapping(
-      value = "/submit",
-      consumes = {APPLICATION_JSON_VALUE, APPLICATION_XML_VALUE})
+  @Autowired
+  private ReceiptMarsService receiptMarsService;
+
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Ok"),
+      @ApiResponse(responseCode = "401", description = "Unauthorized"),
+      @ApiResponse(responseCode = "403", description = "Forbidden"),
+      @ApiResponse(responseCode = "400", description = "Bad request"),
+      @ApiResponse(responseCode = "408", description = "Request Timeout"),
+      @ApiResponse(responseCode = "415", description = "Unsupported media type")
+  })
+  @PostMapping(value = "/submit", consumes = { APPLICATION_JSON_VALUE, APPLICATION_XML_VALUE })
   public String performSubmissionToEna(
       @RequestBody final String submissionPayload,
       @RequestParam(value = "webinUserName") String webinUserName,
@@ -73,9 +83,8 @@ public class WebinIsaToXmlSubmissionController {
 
     final IsaJson isaJson = this.objectMapper.readValue(submissionPayload, IsaJson.class);
     final List<Study> studies = getStudies(isaJson);
-    final Map<String, String> typeToBioSamplesAccessionMap =
-        this.bioSamplesAccessionsParser.parseIsaFileAndGetBioSampleAccessions(
-            studies, new HashMap<>());
+    final Map<String, String> typeToBioSamplesAccessionMap = this.bioSamplesAccessionsParser
+        .parseIsaFileAndGetBioSampleAccessions(studies, new HashMap<>());
 
     final Document document = DocumentHelper.createDocument();
     final Element webinElement = startPreparingWebinV2SubmissionXml(document);
@@ -84,9 +93,8 @@ public class WebinIsaToXmlSubmissionController {
     this.webinStudyXmlCreator.createENAStudySetElement(
         webinElement, studies, randomSubmissionIdentifier);
 
-    final Map<Integer, String> experimentSequenceMap =
-        this.webinExperimentXmlCreator.createENAExperimentSetElement(
-            typeToBioSamplesAccessionMap, webinElement, studies, randomSubmissionIdentifier);
+    final Map<Integer, String> experimentSequenceMap = this.webinExperimentXmlCreator.createENAExperimentSetElement(
+        typeToBioSamplesAccessionMap, webinElement, studies, randomSubmissionIdentifier);
 
     this.webinRunXmlCreator.createENARunSetElement(
         webinElement, studies, experimentSequenceMap, randomSubmissionIdentifier);
@@ -98,11 +106,12 @@ public class WebinIsaToXmlSubmissionController {
 
     writer.write(document);
 
-    final String receiptXml =
-        webinHttpSubmissionService.performWebinSubmission(
-            webinUserName, document.asXML(), webinPassword);
+    final String receiptXml = webinHttpSubmissionService.performWebinSubmission(
+        webinUserName, document.asXML(), webinPassword);
+    final Receipt receiptJson = receiptConversionService.readReceiptXml(receiptXml);
+    final MarsReceipt marsReceipt = receiptMarsService.convertReceiptToMars(receiptJson, isaJson);
 
-    return receiptConversionService.convertReceiptXmlToJson(receiptXml);
+    return receiptMarsService.convertMarsReceiptToJson(marsReceipt);
   }
 
   public List<Study> getStudies(final IsaJson isaJson) {

--- a/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/sra/model/MarsReceipt.java
+++ b/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/sra/model/MarsReceipt.java
@@ -1,0 +1,16 @@
+package com.elixir.biohackaton.ISAToSRA.sra.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class MarsReceipt {
+    private String targetRepository;
+
+    private String[] errors;
+
+    private String[] info;
+
+    private MarsReceiptAccession[] accessions;
+}

--- a/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/sra/model/MarsReceipt.java
+++ b/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/sra/model/MarsReceipt.java
@@ -8,9 +8,9 @@ import lombok.Data;
 public class MarsReceipt {
     private String targetRepository;
 
-    private String[] errors;
+    private MarsReceiptError[] errors;
 
-    private String[] info;
+    private MarsReceiptInfo[] info;
 
     private MarsReceiptAccession[] accessions;
 }

--- a/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/sra/model/MarsReceiptAccession.java
+++ b/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/sra/model/MarsReceiptAccession.java
@@ -1,0 +1,12 @@
+package com.elixir.biohackaton.ISAToSRA.sra.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class MarsReceiptAccession {
+    private String value;
+
+    private MarsReceiptPath[] path;
+}

--- a/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/sra/model/MarsReceiptError.java
+++ b/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/sra/model/MarsReceiptError.java
@@ -1,0 +1,18 @@
+package com.elixir.biohackaton.ISAToSRA.sra.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class MarsReceiptError {
+    private MarsReceiptErrorType type;
+
+    private String message;
+
+    @JsonInclude(Include.NON_NULL)
+    private MarsReceiptPath[] path;
+}

--- a/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/sra/model/MarsReceiptErrorType.java
+++ b/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/sra/model/MarsReceiptErrorType.java
@@ -1,0 +1,6 @@
+package com.elixir.biohackaton.ISAToSRA.sra.model;
+
+public enum MarsReceiptErrorType {
+    INVALID_METADATA,
+    INVALID_DATA;
+}

--- a/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/sra/model/MarsReceiptInfo.java
+++ b/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/sra/model/MarsReceiptInfo.java
@@ -1,0 +1,16 @@
+package com.elixir.biohackaton.ISAToSRA.sra.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class MarsReceiptInfo {
+    @JsonInclude(Include.NON_NULL)
+    private String name;
+
+    private String message;
+}

--- a/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/sra/model/MarsReceiptMessage.java
+++ b/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/sra/model/MarsReceiptMessage.java
@@ -1,0 +1,18 @@
+package com.elixir.biohackaton.ISAToSRA.sra.model;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Builder.Default;
+
+import java.util.List;
+import java.util.ArrayList;
+
+@Builder
+@Data
+public class MarsReceiptMessage {
+    @Default
+    private List<MarsReceiptError> errors = new ArrayList<>();
+
+    @Default
+    private List<MarsReceiptInfo> info= new ArrayList<>();
+}

--- a/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/sra/model/MarsReceiptPath.java
+++ b/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/sra/model/MarsReceiptPath.java
@@ -1,0 +1,16 @@
+package com.elixir.biohackaton.ISAToSRA.sra.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class MarsReceiptPath {
+    private String key;
+
+    @JsonInclude(Include.NON_NULL)
+    private MarsReceiptWhere where;
+}

--- a/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/sra/model/MarsReceiptWhere.java
+++ b/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/sra/model/MarsReceiptWhere.java
@@ -1,0 +1,12 @@
+package com.elixir.biohackaton.ISAToSRA.sra.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class MarsReceiptWhere {
+    private String key;
+
+    private String value;
+}

--- a/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/sra/service/ReceiptMarsService.java
+++ b/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/sra/service/ReceiptMarsService.java
@@ -1,0 +1,213 @@
+/** Elixir BioHackathon 2023 */
+package com.elixir.biohackaton.ISAToSRA.sra.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import com.elixir.biohackaton.ISAToSRA.model.DataFile;
+import com.elixir.biohackaton.ISAToSRA.model.IsaJson;
+import com.elixir.biohackaton.ISAToSRA.model.OtherMaterial;
+import com.elixir.biohackaton.ISAToSRA.model.Sample;
+import com.elixir.biohackaton.ISAToSRA.model.Study;
+import com.elixir.biohackaton.ISAToSRA.sra.model.MarsReceipt;
+import com.elixir.biohackaton.ISAToSRA.sra.model.MarsReceiptAccession;
+import com.elixir.biohackaton.ISAToSRA.sra.model.MarsReceiptPath;
+import com.elixir.biohackaton.ISAToSRA.sra.model.MarsReceiptWhere;
+import com.elixir.biohackaton.ISAToSRA.sra.model.Messages;
+import com.elixir.biohackaton.ISAToSRA.sra.model.Receipt;
+import com.elixir.biohackaton.ISAToSRA.sra.model.ReceiptObject;
+
+@Service
+public class ReceiptMarsService {
+
+  /**
+   * Converting ENA receipt to Mars data format
+   * 
+   * @see https://github.com/elixir-europe/MARS/blob/refactor/repository-services/repository-api.md#response
+   * @param receipt Receipt from ENA
+   * @param isaJson Requested ISA-Json
+   * @return
+   */
+  public MarsReceipt convertReceiptToMars(Receipt receipt, IsaJson isaJson) {
+    Messages messages = receipt.getMessages();
+    List<String> errors = Optional.ofNullable(messages.getErrorMessages()).orElse(new ArrayList<>());
+    List<String> info = Optional.ofNullable(messages.getErrorMessages()).orElse(new ArrayList<>());
+    return MarsReceipt.builder()
+        .targetRepository("ena.embl") // https://registry.identifiers.org/registry/ena.embl
+        .accessions(getMarsAccessions(receipt, isaJson, errors))
+        .errors(errors.toArray(String[]::new))
+        .info(info.toArray(String[]::new))
+        .build();
+  }
+
+  private MarsReceiptAccession[] getMarsAccessions(Receipt receipt, IsaJson isaJson, List<String> errors) {
+    List<MarsReceiptAccession> accessions = new ArrayList<>();
+    if (receipt.isSuccess()) {
+      Optional.ofNullable(isaJson.investigation.studies).orElse(new ArrayList<>()).forEach(study -> {
+        setStudyMarsAccession(accessions, errors, receipt, study);
+        Optional.ofNullable(study.materials.samples).orElse(new ArrayList<>()).forEach(sample -> {
+          setSampleMarsAccession(accessions, errors, receipt, study.title, sample);
+        });
+        Optional.ofNullable(study.assays).orElse(new ArrayList<>()).forEach(assay -> {
+          Optional.ofNullable(assay.materials.otherMaterials).orElse(new ArrayList<>()).forEach(otherMaterial -> {
+            setExperimentMarsAccession(accessions, errors, receipt, study.title, assay.id, otherMaterial);
+          });
+          Optional.ofNullable(assay.dataFiles).orElse(new ArrayList<>()).forEach(dataFile -> {
+            setRunMarsAccession(accessions, errors, receipt, study.title, assay.id, dataFile);
+          });
+        });
+      });
+    }
+
+    return accessions.toArray(MarsReceiptAccession[]::new);
+  }
+
+  //
+  // ---------------------------------
+  // | Setting Mars accession objects |
+  // ---------------------------------
+
+  private void setStudyMarsAccession(
+      List<MarsReceiptAccession> accessions,
+      List<String> errors,
+      Receipt receipt,
+      Study study) {
+    List<ReceiptObject> studies = Optional.ofNullable(receipt.getStudies()).orElse(receipt.getProjects());
+    Optional<ReceiptObject> studyReceipt = Optional.ofNullable(studies)
+        .orElse(new ArrayList<>())
+        .stream()
+        .filter(s -> s.getAlias().equals(study.title))
+        .findAny();
+    if (studyReceipt.isEmpty()) {
+      errors.add(String.format("Cannot find a study with the alias %s in the ENA receipt", study.title));
+      return;
+    }
+    accessions.add(getStudyMarsAccession(study.title, studyReceipt.get()));
+  }
+
+  private void setSampleMarsAccession(List<MarsReceiptAccession> accessions,
+      List<String> errors,
+      Receipt receipt,
+      String studyTitle,
+      Sample sample) {
+    Optional<ReceiptObject> sampleReceipt = Optional.ofNullable(receipt.getSamples())
+        .orElse(new ArrayList<>())
+        .stream()
+        .filter(s -> s.getAlias().equals(sample.id))
+        .findAny();
+    if (sampleReceipt.isEmpty()) {
+      errors.add(String.format("Cannot find a sample with the alias %s in the ENA receipt", sample.id));
+      return;
+    }
+    accessions.add(getSampleMarsAccession(studyTitle, sample.id, sampleReceipt.get()));
+  }
+
+  private void setExperimentMarsAccession(List<MarsReceiptAccession> accessions,
+      List<String> errors,
+      Receipt receipt,
+      String studyTitle,
+      String assayId,
+      OtherMaterial otherMaterial) {
+    Optional<ReceiptObject> experimentReceipt = Optional.ofNullable(receipt.getExperiments())
+        .orElse(new ArrayList<>())
+        .stream()
+        .filter(s -> s.getAlias().equals(otherMaterial.id))
+        .findAny();
+    if (experimentReceipt.isEmpty()) {
+      errors.add(String.format("Cannot find an experiment with the alias %s in the ENA receipt", otherMaterial.id));
+      return;
+    }
+    accessions.add(getExperimentMarsAccession(studyTitle, assayId, otherMaterial.id, experimentReceipt.get()));
+  }
+
+  private void setRunMarsAccession(List<MarsReceiptAccession> accessions,
+      List<String> errors,
+      Receipt receipt,
+      String studyTitle,
+      String assayId,
+      DataFile dataFile) {
+    Optional<ReceiptObject> runReceipt = Optional.ofNullable(receipt.getRuns())
+        .orElse(new ArrayList<>())
+        .stream()
+        .filter(s -> s.getAlias().equals(dataFile.id))
+        .findAny();
+    if (runReceipt.isEmpty()) {
+      errors.add(String.format("Cannot find a run with the alias %s in the ENA receipt", dataFile.id));
+      return;
+    }
+    accessions.add(getRunMarsAccession(studyTitle, assayId, dataFile.id, runReceipt.get()));
+  }
+  //
+  // ---------------------------------
+  // | Making Mars accession objects |
+  // ---------------------------------
+
+  private MarsReceiptAccession getStudyMarsAccession(String title, ReceiptObject studyReceipt) {
+    return MarsReceiptAccession.builder()
+        .path(new MarsReceiptPath[] {
+            MarsReceiptPath.builder().key("investigation").build(),
+            MarsReceiptPath.builder().key("studies")
+                .where(MarsReceiptWhere.builder().key("title").value(title).build()).build()
+        })
+        .value(studyReceipt.getAccession())
+        .build();
+  }
+
+  private MarsReceiptAccession getSampleMarsAccession(String studyTitle, String sampleId, ReceiptObject sampleReceipt) {
+    return MarsReceiptAccession.builder()
+        .path(new MarsReceiptPath[] {
+            MarsReceiptPath.builder().key("investigation").build(),
+            MarsReceiptPath.builder().key("studies")
+                .where(MarsReceiptWhere.builder().key("title").value(studyTitle).build()).build(),
+            MarsReceiptPath.builder().key("materials").build(),
+            MarsReceiptPath.builder().key("samples")
+                .where(MarsReceiptWhere.builder().key("@id").value(sampleId).build()).build()
+        })
+        .value(sampleReceipt.getAccession())
+        .build();
+  }
+
+  private MarsReceiptAccession getExperimentMarsAccession(
+      String studyTitle,
+      String assayId,
+      String otherMaterialId,
+      ReceiptObject experimentReceipt) {
+    return MarsReceiptAccession.builder()
+        .path(new MarsReceiptPath[] {
+            MarsReceiptPath.builder().key("investigation").build(),
+            MarsReceiptPath.builder().key("studies")
+                .where(MarsReceiptWhere.builder().key("title").value(studyTitle).build()).build(),
+            MarsReceiptPath.builder().key("assays")
+                .where(MarsReceiptWhere.builder().key("@id").value(assayId).build()).build(),
+            MarsReceiptPath.builder().key("materials").build(),
+            MarsReceiptPath.builder().key("otherMaterials")
+                .where(MarsReceiptWhere.builder().key("@id").value(otherMaterialId).build()).build(),
+
+        })
+        .value(experimentReceipt.getAccession())
+        .build();
+  }
+
+  private MarsReceiptAccession getRunMarsAccession(
+      String studyTitle,
+      String assayId,
+      String dataFileId,
+      ReceiptObject runReceipt) {
+    return MarsReceiptAccession.builder()
+        .path(new MarsReceiptPath[] {
+            MarsReceiptPath.builder().key("investigation").build(),
+            MarsReceiptPath.builder().key("studies")
+                .where(MarsReceiptWhere.builder().key("title").value(studyTitle).build()).build(),
+            MarsReceiptPath.builder().key("assays")
+                .where(MarsReceiptWhere.builder().key("@id").value(assayId).build()).build(),
+            MarsReceiptPath.builder().key("dataFiles")
+                .where(MarsReceiptWhere.builder().key("@id").value(dataFileId).build()).build(),
+
+        })
+        .value(runReceipt.getAccession())
+        .build();
+  }
+}

--- a/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/sra/service/ReceiptMarsService.java
+++ b/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/sra/service/ReceiptMarsService.java
@@ -34,7 +34,7 @@ public class ReceiptMarsService {
   public MarsReceipt convertReceiptToMars(Receipt receipt, IsaJson isaJson) {
     Messages messages = receipt.getMessages();
     List<String> errors = Optional.ofNullable(messages.getErrorMessages()).orElse(new ArrayList<>());
-    List<String> info = Optional.ofNullable(messages.getErrorMessages()).orElse(new ArrayList<>());
+    List<String> info = Optional.ofNullable(messages.getInfoMessages()).orElse(new ArrayList<>());
     return MarsReceipt.builder()
         .targetRepository("ena.embl") // https://registry.identifiers.org/registry/ena.embl
         .accessions(getMarsAccessions(receipt, isaJson, errors))

--- a/repository-services/isajson-ena/src/test/java/com/elixir/biohackaton/ISAToSRA/EnaReceiptToMarsTest.java
+++ b/repository-services/isajson-ena/src/test/java/com/elixir/biohackaton/ISAToSRA/EnaReceiptToMarsTest.java
@@ -1,0 +1,45 @@
+/** Elixir BioHackathon 2023 */
+package com.elixir.biohackaton.ISAToSRA;
+
+import java.io.File;
+import java.nio.file.Files;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.elixir.biohackaton.ISAToSRA.model.IsaJson;
+import com.elixir.biohackaton.ISAToSRA.sra.model.MarsReceipt;
+import com.elixir.biohackaton.ISAToSRA.sra.model.Receipt;
+import com.elixir.biohackaton.ISAToSRA.sra.service.ReceiptMarsService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+class EnaReceiptToMarsTest {
+
+  @Test
+  void convertToMars() {
+    try {
+
+      // Reading Inputs
+      String enaReceiptFilePath = "../../test-data/ena-receipt.json";
+      String isaJsonFilePath = "../../test-data/biosamples-input-isa.json";
+      String receiptFile = Files.readString(new File(enaReceiptFilePath).toPath());
+      String isaJsonFile = Files.readString(new File(isaJsonFilePath).toPath());
+
+      // Mapping inputs to the proper objects
+      ObjectMapper jsonMapper = new ObjectMapper();
+      Receipt receipt = jsonMapper.readValue(receiptFile, Receipt.class);
+      IsaJson isaJson = jsonMapper.readValue(isaJsonFile, IsaJson.class);
+
+      // Converting ENA receipt to MARS receipt
+      ReceiptMarsService marsService = new ReceiptMarsService();
+      MarsReceipt marsReceipt = marsService.convertReceiptToMars(receipt, isaJson);
+
+      // Saving the result as a Json file
+      String marsReceiptPath = "../../test-data/mars-ena-receipt.json";
+      Files.write(new File(marsReceiptPath).toPath(), jsonMapper.writeValueAsBytes(marsReceipt));
+    } catch (Exception ex) {
+      System.console().printf("%s", ex);
+    }
+  }
+}

--- a/test-data/ena-receipt.json
+++ b/test-data/ena-receipt.json
@@ -1,0 +1,55 @@
+{
+    "success": true,
+    "receiptDate": "2023-11-16T10:44:41.618Z",
+    "experiments": [
+        {
+            "alias": "#other_material/332",
+            "accession": "ERX9223136",
+            "status": "PRIVATE"
+        }
+    ],
+    "runs": [
+        {
+            "alias": "#data/334",
+            "accession": "ERR9669128",
+            "status": "PRIVATE"
+        }
+    ],
+    "samples": [
+        {
+            "alias": "#sample/331",
+            "accession": "ERS27605861",
+            "status": "PRIVATE",
+            "holdUntilDate": "2023-01-01Z",
+            "externalAccession": {
+                "id": "SAMEA130793922",
+                "db": "biosample"
+            }
+        }
+    ],
+    "projects": [
+        {
+            "alias": "Arabidopsis thaliana",
+            "accession": "PRJEB101337",
+            "status": "PRIVATE",
+            "holdUntilDate": "2023-01-01Z",
+            "externalAccession": {
+                "id": "ERP201886",
+                "db": "study"
+            }
+        }
+    ],
+    "submission": {
+        "alias": "SUBMISSION-27-07-2022-09:54:36:278",
+        "accession": "ERA12956757"
+    },
+    "messages": {
+        "info": [
+            "All objects in this submission are set to private status (HOLD)."
+        ]
+    },
+    "actions": [
+        "ADD",
+        "HOLD"
+    ]
+}

--- a/test-data/mars-ena-receipt.json
+++ b/test-data/mars-ena-receipt.json
@@ -1,10 +1,44 @@
 {
     "targetRepository": "ena.embl",
     "errors": [
-        "Cannot find an experiment with the alias #other_material/333 in the ENA receipt"
+        {
+            "type": "INVALID_METADATA",
+            "message": "Cannot find an Experiment with the alias #other_material/333 in the ENA receipt",
+            "path": [
+                {
+                    "key": "investigation"
+                },
+                {
+                    "key": "studies",
+                    "where": {
+                        "key": "title",
+                        "value": "Arabidopsis thaliana"
+                    }
+                },
+                {
+                    "key": "assays",
+                    "where": {
+                        "key": "@id",
+                        "value": "#assay/18_20_21"
+                    }
+                },
+                {
+                    "key": "materials"
+                },
+                {
+                    "key": "otherMaterials",
+                    "where": {
+                        "key": "@id",
+                        "value": "#other_material/333"
+                    }
+                }
+            ]
+        }
     ],
     "info": [
-        "All objects in this submission are set to private status (HOLD)."
+        {
+            "message": "All objects in this submission are set to private status (HOLD)."
+        }
     ],
     "accessions": [
         {

--- a/test-data/mars-ena-receipt.json
+++ b/test-data/mars-ena-receipt.json
@@ -1,0 +1,110 @@
+{
+    "targetRepository": "ena.embl",
+    "errors": [
+        "Cannot find an experiment with the alias #other_material/333 in the ENA receipt"
+    ],
+    "info": [],
+    "accessions": [
+        {
+            "value": "PRJEB101337",
+            "path": [
+                {
+                    "key": "investigation"
+                },
+                {
+                    "key": "studies",
+                    "where": {
+                        "key": "title",
+                        "value": "Arabidopsis thaliana"
+                    }
+                }
+            ]
+        },
+        {
+            "value": "ERS27605861",
+            "path": [
+                {
+                    "key": "investigation"
+                },
+                {
+                    "key": "studies",
+                    "where": {
+                        "key": "title",
+                        "value": "Arabidopsis thaliana"
+                    }
+                },
+                {
+                    "key": "materials"
+                },
+                {
+                    "key": "samples",
+                    "where": {
+                        "key": "@id",
+                        "value": "#sample/331"
+                    }
+                }
+            ]
+        },
+        {
+            "value": "ERX9223136",
+            "path": [
+                {
+                    "key": "investigation"
+                },
+                {
+                    "key": "studies",
+                    "where": {
+                        "key": "title",
+                        "value": "Arabidopsis thaliana"
+                    }
+                },
+                {
+                    "key": "assays",
+                    "where": {
+                        "key": "@id",
+                        "value": "#assay/18_20_21"
+                    }
+                },
+                {
+                    "key": "materials"
+                },
+                {
+                    "key": "otherMaterials",
+                    "where": {
+                        "key": "@id",
+                        "value": "#other_material/332"
+                    }
+                }
+            ]
+        },
+        {
+            "value": "ERR9669128",
+            "path": [
+                {
+                    "key": "investigation"
+                },
+                {
+                    "key": "studies",
+                    "where": {
+                        "key": "title",
+                        "value": "Arabidopsis thaliana"
+                    }
+                },
+                {
+                    "key": "assays",
+                    "where": {
+                        "key": "@id",
+                        "value": "#assay/18_20_21"
+                    }
+                },
+                {
+                    "key": "dataFiles",
+                    "where": {
+                        "key": "@id",
+                        "value": "#data/334"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/test-data/mars-ena-receipt.json
+++ b/test-data/mars-ena-receipt.json
@@ -3,7 +3,9 @@
     "errors": [
         "Cannot find an experiment with the alias #other_material/333 in the ENA receipt"
     ],
-    "info": [],
+    "info": [
+        "All objects in this submission are set to private status (HOLD)."
+    ],
     "accessions": [
         {
             "value": "PRJEB101337",


### PR DESCRIPTION
Converting ENA receipt to MARS receipt:  
- You can find the MARS receipt structure [here](https://docs.google.com/document/d/1oJvnMpzpsVr6BNWs_DdSiRvhVx1zbHhO-0ITQby1SQo/edit#heading=h.wgboj8yjxnq5). 
  - For ERROR that comes from ENA, there is no way to set "path" on the "errors" field of MarsReceipt. 
  - For INFO that comes from ENA, there is no way to set "name" on the "info" field of MarsReceipt. @apriltuesday 
- Testing is available in [EnaReceiptToMarsTest](repository-services/isajson-ena/src/test/java/com/elixir/biohackaton/ISAToSRA/EnaReceiptToMarsTest.java) and it stores the result in "**test-data/ena-receipt.json**".
- The end-point _/isaena/submit_ (performSubmissionToEna) sends **MarsReceipt** instead of **Receipt**.