### PR TITLE
Align source and sample attribute handling across BioSamples and ENA

### DIFF
--- a/repository-services/docker-compose.yml
+++ b/repository-services/docker-compose.yml
@@ -1,17 +1,16 @@
 services:
   isa_biosamples:
       build:
-        context: .
-        dockerfile: isajson-biosamples/Dockerfile
+        context: ..
+        dockerfile: repository-services/isajson-biosamples/Dockerfile
       ports:
         - "8032:8032"
       restart: unless-stopped
 
   isa_sra:
       build:
-        context: .
-        dockerfile: isajson-ena/Dockerfile
+        context: ..
+        dockerfile: repository-services/isajson-ena/Dockerfile
       ports:
         - "8042:8042"
       restart: unless-stopped
-

--- a/repository-services/isajson-biosamples/src/main/java/com/elixir/biohackaton/ISAToSRA/biosamples/service/BioSamplesSubmitter.java
+++ b/repository-services/isajson-biosamples/src/main/java/com/elixir/biohackaton/ISAToSRA/biosamples/service/BioSamplesSubmitter.java
@@ -76,9 +76,9 @@ public class BioSamplesSubmitter {
                 || attribute
                     .getType()
                     .equalsIgnoreCase("geographic location (country and/or sea)"));
-    childSampleAttributes.add(Attribute.build("collection date", "Not provided"));
+    childSampleAttributes.add(Attribute.build("collection date", "not provided"));
     childSampleAttributes.add(
-        Attribute.build("geographic location (country and/or sea)", "Not provided"));
+        Attribute.build("geographic location (country and/or sea)", "not provided"));
     final BioSample bioSample =
         new BioSample.Builder(sample.getName() != null ? sample.getName() : "child_sample")
             .withRelease(Instant.now())

--- a/repository-services/isajson-biosamples/src/main/java/com/elixir/biohackaton/ISAToSRA/biosamples/service/BioSamplesSubmitter.java
+++ b/repository-services/isajson-biosamples/src/main/java/com/elixir/biohackaton/ISAToSRA/biosamples/service/BioSamplesSubmitter.java
@@ -66,19 +66,11 @@ public class BioSamplesSubmitter {
 
   private BioSample createAndUpdateChildSampleWithRelationship(
       final Sample sample, final BioSample sourceBioSample, final String webinToken) {
-    // Create a copy of the attributes to avoid mutating the source BioSample
     final SortedSet<Attribute> childSampleAttributes =
-        new TreeSet<>(sourceBioSample.getAttributes());
-    childSampleAttributes.removeIf(
-        attribute ->
-            attribute.getType().equalsIgnoreCase("SRA accession")
-                || attribute.getType().equalsIgnoreCase("collection date")
-                || attribute
-                    .getType()
-                    .equalsIgnoreCase("geographic location (country and/or sea)"));
-    childSampleAttributes.add(Attribute.build("collection date", "not provided"));
-    childSampleAttributes.add(
-        Attribute.build("geographic location (country and/or sea)", "not provided"));
+        buildAttributesFromCharacteristics(sample.getCharacteristics());
+    ensureMandatorySampleAttribute(childSampleAttributes, "collection date", "not provided");
+    ensureMandatorySampleAttribute(
+        childSampleAttributes, "geographic location (country and/or sea)", "not provided");
     final BioSample bioSample =
         new BioSample.Builder(sample.getName() != null ? sample.getName() : "child_sample")
             .withRelease(Instant.now())
@@ -109,7 +101,6 @@ public class BioSamplesSubmitter {
 
   private List<BioSample> createSourceBioSample(
       final List<Study> studies, final String webinToken) {
-    final List<Attribute> attributes = new ArrayList<>();
     List<BioSample> biosamples = new ArrayList<>();
 
     studies.forEach(
@@ -119,6 +110,7 @@ public class BioSamplesSubmitter {
                 .getSources()
                 .forEach(
                     source -> {
+                      final List<Attribute> attributes = new ArrayList<>();
                       source
                           .getCharacteristics()
                           .forEach(
@@ -142,6 +134,43 @@ public class BioSamplesSubmitter {
                     }));
 
     return biosamples;
+  }
+
+  private SortedSet<Attribute> buildAttributesFromCharacteristics(
+      final List<Characteristic> characteristics) {
+    final SortedSet<Attribute> attributes = new TreeSet<>();
+
+    if (characteristics == null) {
+      return attributes;
+    }
+
+    characteristics.forEach(
+        characteristic -> {
+          if (characteristic == null
+              || characteristic.getCategory() == null
+              || characteristic.getValue() == null) {
+            return;
+          }
+
+          final String key = getCharacteristicKey(characteristic.getCategory());
+          final String value = characteristic.getValue().getAnnotationValue();
+
+          if (key != null && value != null) {
+            attributes.add(Attribute.build(key, value));
+          }
+        });
+
+    return attributes;
+  }
+
+  private void ensureMandatorySampleAttribute(
+      final SortedSet<Attribute> attributes, final String type, final String value) {
+    final boolean alreadyPresent =
+        attributes.stream().anyMatch(attribute -> attribute.getType().equalsIgnoreCase(type));
+
+    if (!alreadyPresent) {
+      attributes.add(Attribute.build(type, value));
+    }
   }
 
   private static Characteristic getBioSampleAccessionCharacteristic(

--- a/repository-services/isajson-biosamples/src/main/java/com/elixir/biohackaton/ISAToSRA/biosamples/service/BioSamplesSubmitter.java
+++ b/repository-services/isajson-biosamples/src/main/java/com/elixir/biohackaton/ISAToSRA/biosamples/service/BioSamplesSubmitter.java
@@ -37,6 +37,8 @@ public class BioSamplesSubmitter {
 
       studies.forEach(
           study -> {
+            final Map<String, String> characteristicKeyLookup =
+                buildCharacteristicKeyLookup(study);
             typeToBioSamplesAccessionMap.studyAccessionsMap =
                 new ReceiptAccessionsMap(Study.Fields.title, study.getTitle());
 
@@ -47,7 +49,7 @@ public class BioSamplesSubmitter {
                     sample -> {
                       final BioSample persistedChildSample =
                           this.createAndUpdateChildSampleWithRelationship(
-                              sample, sourceBioSample, webinToken);
+                              sample, sourceBioSample, webinToken, characteristicKeyLookup);
 
                       if (persistedChildSample != null) {
                         typeToBioSamplesAccessionMap.sampleAccessionsMap.isaItemName =
@@ -65,9 +67,12 @@ public class BioSamplesSubmitter {
   }
 
   private BioSample createAndUpdateChildSampleWithRelationship(
-      final Sample sample, final BioSample sourceBioSample, final String webinToken) {
+      final Sample sample,
+      final BioSample sourceBioSample,
+      final String webinToken,
+      final Map<String, String> characteristicKeyLookup) {
     final SortedSet<Attribute> childSampleAttributes =
-        buildAttributesFromCharacteristics(sample.getCharacteristics());
+        buildAttributesFromCharacteristics(sample.getCharacteristics(), characteristicKeyLookup);
     copySourceAttributeIfMissing(childSampleAttributes, sourceBioSample, "organism");
     copySourceAttributeIfMissing(childSampleAttributes, sourceBioSample, "tax_id");
     ensureMandatorySampleAttribute(
@@ -115,6 +120,8 @@ public class BioSamplesSubmitter {
                 .getSources()
                 .forEach(
                     source -> {
+                      final Map<String, String> characteristicKeyLookup =
+                          buildCharacteristicKeyLookup(study);
                       final List<Attribute> attributes = new ArrayList<>();
                       source
                           .getCharacteristics()
@@ -122,7 +129,8 @@ public class BioSamplesSubmitter {
                               characteristic -> {
                                 if (characteristic.getCategory().getId() != null) {
                                   final String extractedKey =
-                                      getCharacteristicKey(characteristic.getCategory());
+                                      getCharacteristicKey(
+                                          characteristic.getCategory(), characteristicKeyLookup);
 
                                   attributes.add(
                                       Attribute.build(
@@ -142,7 +150,7 @@ public class BioSamplesSubmitter {
   }
 
   private SortedSet<Attribute> buildAttributesFromCharacteristics(
-      final List<Characteristic> characteristics) {
+      final List<Characteristic> characteristics, final Map<String, String> characteristicKeyLookup) {
     final SortedSet<Attribute> attributes = new TreeSet<>();
 
     if (characteristics == null) {
@@ -157,7 +165,8 @@ public class BioSamplesSubmitter {
             return;
           }
 
-          final String key = getCharacteristicKey(characteristic.getCategory());
+          final String key =
+              getCharacteristicKey(characteristic.getCategory(), characteristicKeyLookup);
           final String value = characteristic.getValue().getAnnotationValue();
 
           if (key != null && value != null) {
@@ -166,6 +175,31 @@ public class BioSamplesSubmitter {
         });
 
     return attributes;
+  }
+
+  private Map<String, String> buildCharacteristicKeyLookup(final Study study) {
+    final Map<String, String> keyLookup = new HashMap<>();
+
+    if (study == null || study.getCharacteristicCategories() == null) {
+      return keyLookup;
+    }
+
+    study.getCharacteristicCategories().forEach(
+        characteristicCategory -> {
+          if (characteristicCategory == null
+              || characteristicCategory.getId() == null
+              || characteristicCategory.getCharacteristicType() == null
+              || characteristicCategory.getCharacteristicType().getAnnotationValue() == null
+              || characteristicCategory.getCharacteristicType().getAnnotationValue().isBlank()) {
+            return;
+          }
+
+          keyLookup.put(
+              characteristicCategory.getId(),
+              characteristicCategory.getCharacteristicType().getAnnotationValue());
+        });
+
+    return keyLookup;
   }
 
   private void ensureMandatorySampleAttribute(
@@ -212,20 +246,16 @@ public class BioSamplesSubmitter {
   }
 
   /**
-   * Uses the human-readable ISA annotation value as the BioSamples attribute key.
+   * Uses the study-level ISA characteristic definition to resolve the human-readable attribute
+   * name for a characteristic id.
    */
-  private static String getCharacteristicKey(final Category category) {
-    if (category == null) {
+  private static String getCharacteristicKey(
+      final Category category, final Map<String, String> characteristicKeyLookup) {
+    if (category == null || category.getId() == null) {
       return null;
     }
 
-    if (category.getCharacteristicType() != null
-        && category.getCharacteristicType().getAnnotationValue() != null
-        && !category.getCharacteristicType().getAnnotationValue().isBlank()) {
-      return category.getCharacteristicType().getAnnotationValue();
-    }
-
-    return null;
+    return characteristicKeyLookup.get(category.getId());
   }
 
   private BioSample updateSampleWithRelationshipsToBioSamples(

--- a/repository-services/isajson-biosamples/src/main/java/com/elixir/biohackaton/ISAToSRA/biosamples/service/BioSamplesSubmitter.java
+++ b/repository-services/isajson-biosamples/src/main/java/com/elixir/biohackaton/ISAToSRA/biosamples/service/BioSamplesSubmitter.java
@@ -73,14 +73,11 @@ public class BioSamplesSubmitter {
       final Map<String, String> characteristicKeyLookup) {
     final SortedSet<Attribute> childSampleAttributes =
         buildAttributesFromCharacteristics(sample.getCharacteristics(), characteristicKeyLookup);
-    copySourceAttributeIfMissing(childSampleAttributes, sourceBioSample, "organism");
-    copySourceAttributeIfMissing(childSampleAttributes, sourceBioSample, "tax_id");
-    ensureMandatorySampleAttribute(
-        childSampleAttributes, "collection date", "not provided");
-    ensureMandatorySampleAttribute(
-        childSampleAttributes,
-        "geographic location (country and/or sea)",
-        "not provided");
+    synchronizeSharedAttribute(childSampleAttributes, sourceBioSample, "organism");
+    synchronizeSharedAttribute(childSampleAttributes, sourceBioSample, "tax_id");
+    copySourceAttributeIfMissing(childSampleAttributes, sourceBioSample, "collection date");
+    copySourceAttributeIfMissing(
+        childSampleAttributes, sourceBioSample, "geographic location (country and/or sea)");
     final BioSample bioSample =
         new BioSample.Builder(sample.getName() != null ? sample.getName() : "child_sample")
             .withRelease(Instant.now())
@@ -202,16 +199,6 @@ public class BioSamplesSubmitter {
     return keyLookup;
   }
 
-  private void ensureMandatorySampleAttribute(
-      final SortedSet<Attribute> attributes, final String type, final String value) {
-    final boolean alreadyPresent =
-        attributes.stream().anyMatch(attribute -> attribute.getType().equalsIgnoreCase(type));
-
-    if (!alreadyPresent) {
-      attributes.add(Attribute.build(type, value));
-    }
-  }
-
   private void copySourceAttributeIfMissing(
       final SortedSet<Attribute> childAttributes,
       final BioSample sourceBioSample,
@@ -228,6 +215,32 @@ public class BioSamplesSubmitter {
         .filter(attribute -> attribute.getType().equalsIgnoreCase(attributeType))
         .findFirst()
         .ifPresent(childAttributes::add);
+  }
+
+  private void synchronizeSharedAttribute(
+      final SortedSet<Attribute> childAttributes,
+      final BioSample sourceBioSample,
+      final String attributeType) {
+    final Optional<Attribute> childAttribute =
+        childAttributes.stream()
+            .filter(attribute -> attribute.getType().equalsIgnoreCase(attributeType))
+            .findFirst();
+
+    final Optional<Attribute> sourceAttribute =
+        sourceBioSample.getAttributes() == null
+            ? Optional.empty()
+            : sourceBioSample.getAttributes().stream()
+                .filter(attribute -> attribute.getType().equalsIgnoreCase(attributeType))
+                .findFirst();
+
+    if (childAttribute.isPresent() && sourceAttribute.isEmpty()) {
+      sourceBioSample.getAttributes().add(childAttribute.get());
+      return;
+    }
+
+    if (childAttribute.isEmpty() && sourceAttribute.isPresent()) {
+      childAttributes.add(sourceAttribute.get());
+    }
   }
 
   private static Characteristic getBioSampleAccessionCharacteristic(

--- a/repository-services/isajson-biosamples/src/main/java/com/elixir/biohackaton/ISAToSRA/biosamples/service/BioSamplesSubmitter.java
+++ b/repository-services/isajson-biosamples/src/main/java/com/elixir/biohackaton/ISAToSRA/biosamples/service/BioSamplesSubmitter.java
@@ -70,7 +70,15 @@ public class BioSamplesSubmitter {
     final SortedSet<Attribute> childSampleAttributes =
         new TreeSet<>(sourceBioSample.getAttributes());
     childSampleAttributes.removeIf(
-        attribute -> attribute.getType().equalsIgnoreCase("SRA accession"));
+        attribute ->
+            attribute.getType().equalsIgnoreCase("SRA accession")
+                || attribute.getType().equalsIgnoreCase("collection date")
+                || attribute
+                    .getType()
+                    .equalsIgnoreCase("geographic location (country and/or sea)"));
+    childSampleAttributes.add(Attribute.build("collection date", "Not provided"));
+    childSampleAttributes.add(
+        Attribute.build("geographic location (country and/or sea)", "Not provided"));
     final BioSample bioSample =
         new BioSample.Builder(sample.getName() != null ? sample.getName() : "child_sample")
             .withRelease(Instant.now())

--- a/repository-services/isajson-biosamples/src/main/java/com/elixir/biohackaton/ISAToSRA/biosamples/service/BioSamplesSubmitter.java
+++ b/repository-services/isajson-biosamples/src/main/java/com/elixir/biohackaton/ISAToSRA/biosamples/service/BioSamplesSubmitter.java
@@ -212,8 +212,7 @@ public class BioSamplesSubmitter {
   }
 
   /**
-   * Uses the human-readable annotation value when available, otherwise falls back to a concise key
-   * derived from the category id.
+   * Uses the human-readable ISA annotation value as the BioSamples attribute key.
    */
   private static String getCharacteristicKey(final Category category) {
     if (category == null) {
@@ -226,19 +225,7 @@ public class BioSamplesSubmitter {
       return category.getCharacteristicType().getAnnotationValue();
     }
 
-    final String categoryId = category.getId();
-    if (categoryId == null) {
-      return null;
-    }
-
-    final String prefix = "#characteristic_category/";
-
-    if (!categoryId.startsWith(prefix)) {
-      return categoryId;
-    }
-
-    // Strip a trailing underscore followed by digits, if present
-    return categoryId.substring(prefix.length()).replaceFirst("_[0-9]+$", "");
+    return null;
   }
 
   private BioSample updateSampleWithRelationshipsToBioSamples(

--- a/repository-services/isajson-biosamples/src/main/java/com/elixir/biohackaton/ISAToSRA/biosamples/service/BioSamplesSubmitter.java
+++ b/repository-services/isajson-biosamples/src/main/java/com/elixir/biohackaton/ISAToSRA/biosamples/service/BioSamplesSubmitter.java
@@ -116,8 +116,8 @@ public class BioSamplesSubmitter {
                           .forEach(
                               characteristic -> {
                                 if (characteristic.getCategory().getId() != null) {
-                                  final String rawId = characteristic.getCategory().getId();
-                                  final String extractedKey = extractCharacteristicKey(rawId);
+                                  final String extractedKey =
+                                      getCharacteristicKey(characteristic.getCategory());
 
                                   attributes.add(
                                       Attribute.build(
@@ -152,12 +152,21 @@ public class BioSamplesSubmitter {
   }
 
   /**
-   * Extracts a concise key from a characteristic category id. Example:
-   * "#characteristic_category/collection_date_323" -> "collection_date"
-   * "#characteristic_category/isolation_source_324" -> "isolation_source" Falls back to the
-   * original id if it doesn't match the expected pattern.
+   * Uses the human-readable annotation value when available, otherwise falls back to a concise key
+   * derived from the category id.
    */
-  private static String extractCharacteristicKey(final String categoryId) {
+  private static String getCharacteristicKey(final Category category) {
+    if (category == null) {
+      return null;
+    }
+
+    if (category.getCharacteristicType() != null
+        && category.getCharacteristicType().getAnnotationValue() != null
+        && !category.getCharacteristicType().getAnnotationValue().isBlank()) {
+      return category.getCharacteristicType().getAnnotationValue();
+    }
+
+    final String categoryId = category.getId();
     if (categoryId == null) {
       return null;
     }

--- a/repository-services/isajson-biosamples/src/main/java/com/elixir/biohackaton/ISAToSRA/biosamples/service/BioSamplesSubmitter.java
+++ b/repository-services/isajson-biosamples/src/main/java/com/elixir/biohackaton/ISAToSRA/biosamples/service/BioSamplesSubmitter.java
@@ -70,9 +70,12 @@ public class BioSamplesSubmitter {
         buildAttributesFromCharacteristics(sample.getCharacteristics());
     copySourceAttributeIfMissing(childSampleAttributes, sourceBioSample, "organism");
     copySourceAttributeIfMissing(childSampleAttributes, sourceBioSample, "tax_id");
-    ensureMandatorySampleAttribute(childSampleAttributes, "collection date", "not provided");
     ensureMandatorySampleAttribute(
-        childSampleAttributes, "geographic location (country and/or sea)", "not provided");
+        childSampleAttributes, "collection_date", "not provided");
+    ensureMandatorySampleAttribute(
+        childSampleAttributes,
+        "geographic_location_(country_and/or_sea)",
+        "not provided");
     final BioSample bioSample =
         new BioSample.Builder(sample.getName() != null ? sample.getName() : "child_sample")
             .withRelease(Instant.now())

--- a/repository-services/isajson-biosamples/src/main/java/com/elixir/biohackaton/ISAToSRA/biosamples/service/BioSamplesSubmitter.java
+++ b/repository-services/isajson-biosamples/src/main/java/com/elixir/biohackaton/ISAToSRA/biosamples/service/BioSamplesSubmitter.java
@@ -68,6 +68,8 @@ public class BioSamplesSubmitter {
       final Sample sample, final BioSample sourceBioSample, final String webinToken) {
     final SortedSet<Attribute> childSampleAttributes =
         buildAttributesFromCharacteristics(sample.getCharacteristics());
+    copySourceAttributeIfMissing(childSampleAttributes, sourceBioSample, "organism");
+    copySourceAttributeIfMissing(childSampleAttributes, sourceBioSample, "tax_id");
     ensureMandatorySampleAttribute(childSampleAttributes, "collection date", "not provided");
     ensureMandatorySampleAttribute(
         childSampleAttributes, "geographic location (country and/or sea)", "not provided");
@@ -171,6 +173,24 @@ public class BioSamplesSubmitter {
     if (!alreadyPresent) {
       attributes.add(Attribute.build(type, value));
     }
+  }
+
+  private void copySourceAttributeIfMissing(
+      final SortedSet<Attribute> childAttributes,
+      final BioSample sourceBioSample,
+      final String attributeType) {
+    final boolean alreadyPresent =
+        childAttributes.stream()
+            .anyMatch(attribute -> attribute.getType().equalsIgnoreCase(attributeType));
+
+    if (alreadyPresent || sourceBioSample.getAttributes() == null) {
+      return;
+    }
+
+    sourceBioSample.getAttributes().stream()
+        .filter(attribute -> attribute.getType().equalsIgnoreCase(attributeType))
+        .findFirst()
+        .ifPresent(childAttributes::add);
   }
 
   private static Characteristic getBioSampleAccessionCharacteristic(

--- a/repository-services/isajson-biosamples/src/main/java/com/elixir/biohackaton/ISAToSRA/biosamples/service/BioSamplesSubmitter.java
+++ b/repository-services/isajson-biosamples/src/main/java/com/elixir/biohackaton/ISAToSRA/biosamples/service/BioSamplesSubmitter.java
@@ -71,10 +71,10 @@ public class BioSamplesSubmitter {
     copySourceAttributeIfMissing(childSampleAttributes, sourceBioSample, "organism");
     copySourceAttributeIfMissing(childSampleAttributes, sourceBioSample, "tax_id");
     ensureMandatorySampleAttribute(
-        childSampleAttributes, "collection_date", "not provided");
+        childSampleAttributes, "collection date", "not provided");
     ensureMandatorySampleAttribute(
         childSampleAttributes,
-        "geographic_location_(country_and/or_sea)",
+        "geographic location (country and/or sea)",
         "not provided");
     final BioSample bioSample =
         new BioSample.Builder(sample.getName() != null ? sample.getName() : "child_sample")

--- a/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/controller/WebinIsaToXmlSubmissionController.java
+++ b/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/controller/WebinIsaToXmlSubmissionController.java
@@ -279,9 +279,12 @@ public class WebinIsaToXmlSubmissionController {
     }
 
     for (Study study : studies) {
+      final Map<String, String> characteristicKeyLookup = buildCharacteristicKeyLookup(study);
+
       if (study.materials != null && study.materials.samples != null) {
         for (Sample sample : study.materials.samples) {
-          String sampleAccession = getCharacteresticAnnotation(sample.characteristics);
+          String sampleAccession =
+              getCharacteresticAnnotation(sample.characteristics, characteristicKeyLookup);
           if (sampleAccession != null && !sampleAccession.isBlank()) {
             biosamples.put("SOURCE", sampleAccession);
             return biosamples;
@@ -291,7 +294,8 @@ public class WebinIsaToXmlSubmissionController {
 
       if (study.materials != null && study.materials.sources != null) {
         for (Source source : study.materials.sources) {
-          String sourceAccession = getCharacteresticAnnotation(source.characteristics);
+          String sourceAccession =
+              getCharacteresticAnnotation(source.characteristics, characteristicKeyLookup);
           if (sourceAccession != null && !sourceAccession.isBlank()) {
             biosamples.put("SOURCE", sourceAccession);
             return biosamples;
@@ -303,6 +307,30 @@ public class WebinIsaToXmlSubmissionController {
     return biosamples;
   }
 
+  private Map<String, String> buildCharacteristicKeyLookup(final Study study) {
+    final Map<String, String> keyLookup = new HashMap<>();
+
+    if (study == null || study.characteristicCategories == null) {
+      return keyLookup;
+    }
+
+    for (CharacteristicCategory characteristicCategory : study.characteristicCategories) {
+      if (characteristicCategory == null
+          || characteristicCategory.id == null
+          || characteristicCategory.characteristicType == null
+          || characteristicCategory.characteristicType.annotationValue == null
+          || characteristicCategory.characteristicType.annotationValue.isBlank()) {
+        continue;
+      }
+
+      keyLookup.put(
+          characteristicCategory.id,
+          characteristicCategory.characteristicType.annotationValue);
+    }
+
+    return keyLookup;
+  }
+
   /**
    * Extracts a BioSamples accession from ISA characteristics.
    *
@@ -312,7 +340,8 @@ public class WebinIsaToXmlSubmissionController {
    * @param characteristics list of characteristics to search
    * @return BioSamples accession value, or empty string if not found
    */
-  private String getCharacteresticAnnotation(List<Characteristic> characteristics) {
+  private String getCharacteresticAnnotation(
+      List<Characteristic> characteristics, final Map<String, String> characteristicKeyLookup) {
     if (characteristics == null) {
       return "";
     }
@@ -323,11 +352,16 @@ public class WebinIsaToXmlSubmissionController {
       }
 
       final Category category = characteristic.category;
-      final boolean accessionCategoryIdMatches =
-          category.id != null && category.id.startsWith("#characteristic_category/accession");
+      final String characteristicName =
+          category.id != null ? characteristicKeyLookup.get(category.id) : null;
       final boolean accessionCategoryNameMatches =
-          category.characteristicType != null
-              && "accession".equalsIgnoreCase(category.characteristicType.annotationValue);
+          "accession".equalsIgnoreCase(characteristicName)
+              || (category.characteristicType != null
+                  && "accession".equalsIgnoreCase(category.characteristicType.annotationValue));
+      final boolean accessionCategoryIdMatches =
+          !accessionCategoryNameMatches
+              && category.id != null
+              && category.id.startsWith("#characteristic_category/accession");
 
       if ((accessionCategoryIdMatches || accessionCategoryNameMatches)
           && characteristic.value != null) {

--- a/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/controller/WebinIsaToXmlSubmissionController.java
+++ b/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/controller/WebinIsaToXmlSubmissionController.java
@@ -311,7 +311,7 @@ public class WebinIsaToXmlSubmissionController {
         continue;
       }
 
-      final CharacteristicCategory category = characteristic.category;
+      final Category category = characteristic.category;
       final boolean accessionCategoryIdMatches =
           category.id != null && category.id.startsWith("#characteristic_category/accession");
       final boolean accessionCategoryNameMatches =

--- a/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/controller/WebinIsaToXmlSubmissionController.java
+++ b/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/controller/WebinIsaToXmlSubmissionController.java
@@ -87,7 +87,7 @@ public class WebinIsaToXmlSubmissionController {
    *   <li>Parse ISA-JSON payload
    *   <li>Create ENA XML structure (WEBIN element with SUBMISSION)
    *   <li>Convert Study → ENA STUDY (top-down)
-   *   <li>Get BioSamples accessions for source samples
+   *   <li>Get BioSamples accessions for study samples
    *   <li>Convert Library → ENA EXPERIMENT (bottom-up: DataFile → Library)
    *   <li>Convert DataFile → ENA RUN (bottom-up: DataFile → Experiment reference)
    *   <li>Convert Investigation → ENA PROJECT (top-down)
@@ -140,7 +140,7 @@ public class WebinIsaToXmlSubmissionController {
     this.webinStudyXmlCreator.createENAStudySetElement(
         webinElement, studies, randomSubmissionIdentifier);
 
-    // Step 2: Get BioSamples accessions for source samples (needed for EXPERIMENT)
+    // Step 2: Get BioSamples accessions for study samples (needed for EXPERIMENT)
     // Use provided bioSampleAccessions if available, otherwise extract from ISA-JSON
     final Map<String, String> typeToBioSamplesAccessionMap =
         parseBioSampleAccessions(bioSampleAccessions, studies);
@@ -214,7 +214,7 @@ public class WebinIsaToXmlSubmissionController {
    * Parses BioSamples accessions from input parameter or extracts from ISA-JSON.
    *
    * <p>If the bioSampleAccessions JSON string is provided, it will be parsed and used. Otherwise,
-   * falls back to extracting from ISA-JSON Study sources.
+   * falls back to extracting from ISA-JSON Study samples first, then sources.
    *
    * <p>Expected format: JSON string with "SOURCE" as key, e.g., {@code {"SOURCE":"SAMEA130793922"}}
    *
@@ -304,7 +304,7 @@ public class WebinIsaToXmlSubmissionController {
   }
 
   /**
-   * Extracts BioSamples accession from source characteristics.
+   * Extracts a BioSamples accession from ISA characteristics.
    *
    * <p>Looks for a characteristic with category "#characteristic_category/accession" and returns
    * its value.

--- a/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/controller/WebinIsaToXmlSubmissionController.java
+++ b/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/controller/WebinIsaToXmlSubmissionController.java
@@ -262,20 +262,21 @@ public class WebinIsaToXmlSubmissionController {
   }
 
   /**
-   * Extracts BioSamples accessions from Study samples, falling back to sources.
+   * Extracts BioSamples accessions from Study samples.
    *
-   * <p>ENA experiments should point to the biological sample used in the assay. We therefore look
-   * for a Study sample accession first and only fall back to a source accession if no sample
-   * accession is present.
+   * <p>ENA experiments should point to the biological sample used in the assay. We therefore
+   * require a BioSamples accession on the Study sample.
    *
    * @param studies list of Study objects to search
-   * @return map with "SOURCE" key and BioSamples accession value, or empty map if not found
+   * @return map with "SOURCE" key and BioSamples accession value
+   * @throws IllegalArgumentException if no Study sample has a BioSamples accession
    */
   public Map<String, String> getBiosamples(List<Study> studies) {
     Map<String, String> biosamples = new HashMap<>();
 
     if (studies == null) {
-      return biosamples;
+      throw new IllegalArgumentException(
+          "No studies were provided. ENA submission requires a BioSamples accession on a Study sample.");
     }
 
     for (Study study : studies) {
@@ -291,20 +292,10 @@ public class WebinIsaToXmlSubmissionController {
           }
         }
       }
-
-      if (study.materials != null && study.materials.sources != null) {
-        for (Source source : study.materials.sources) {
-          String sourceAccession =
-              getCharacteresticAnnotation(source.characteristics, characteristicKeyLookup);
-          if (sourceAccession != null && !sourceAccession.isBlank()) {
-            biosamples.put("SOURCE", sourceAccession);
-            return biosamples;
-          }
-        }
-      }
     }
 
-    return biosamples;
+    throw new IllegalArgumentException(
+        "No BioSamples accession found on any Study sample. ENA submission requires a sample accession.");
   }
 
   private Map<String, String> buildCharacteristicKeyLookup(final Study study) {

--- a/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/controller/WebinIsaToXmlSubmissionController.java
+++ b/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/controller/WebinIsaToXmlSubmissionController.java
@@ -262,10 +262,11 @@ public class WebinIsaToXmlSubmissionController {
   }
 
   /**
-   * Extracts BioSamples accessions from Study sources.
+   * Extracts BioSamples accessions from Study samples, falling back to sources.
    *
-   * <p>Looks for source samples that have a BioSamples accession stored in the characteristic with
-   * category "#characteristic_category/accession". Returns the first source accession found.
+   * <p>ENA experiments should point to the biological sample used in the assay. We therefore look
+   * for a Study sample accession first and only fall back to a source accession if no sample
+   * accession is present.
    *
    * @param studies list of Study objects to search
    * @return map with "SOURCE" key and BioSamples accession value, or empty map if not found
@@ -278,6 +279,16 @@ public class WebinIsaToXmlSubmissionController {
     }
 
     for (Study study : studies) {
+      if (study.materials != null && study.materials.samples != null) {
+        for (Sample sample : study.materials.samples) {
+          String sampleAccession = getCharacteresticAnnotation(sample.characteristics);
+          if (sampleAccession != null && !sampleAccession.isBlank()) {
+            biosamples.put("SOURCE", sampleAccession);
+            return biosamples;
+          }
+        }
+      }
+
       if (study.materials != null && study.materials.sources != null) {
         for (Source source : study.materials.sources) {
           String sourceAccession = getCharacteresticAnnotation(source.characteristics);

--- a/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/controller/WebinIsaToXmlSubmissionController.java
+++ b/repository-services/isajson-ena/src/main/java/com/elixir/biohackaton/ISAToSRA/controller/WebinIsaToXmlSubmissionController.java
@@ -307,11 +307,20 @@ public class WebinIsaToXmlSubmissionController {
     }
 
     for (Characteristic characteristic : characteristics) {
-      if (characteristic.category != null
-          && "#characteristic_category/accession".equals(characteristic.category.id)) {
-        if (characteristic.value != null) {
-          return characteristic.value.annotationValue;
-        }
+      if (characteristic.category == null) {
+        continue;
+      }
+
+      final CharacteristicCategory category = characteristic.category;
+      final boolean accessionCategoryIdMatches =
+          category.id != null && category.id.startsWith("#characteristic_category/accession");
+      final boolean accessionCategoryNameMatches =
+          category.characteristicType != null
+              && "accession".equalsIgnoreCase(category.characteristicType.annotationValue);
+
+      if ((accessionCategoryIdMatches || accessionCategoryNameMatches)
+          && characteristic.value != null) {
+        return characteristic.value.annotationValue;
       }
     }
 

--- a/test-data/biosamples-input-isa.json
+++ b/test-data/biosamples-input-isa.json
@@ -1,8 +1,8 @@
 {
   "investigation": {
     "identifier": "investigation1",
-    "title": "Bob's investigation",
-    "description": "",
+    "title": "Bob's investigation project",
+    "description": "Arabidopsis thaliana sequencing project for MARS PoC validation.",
     "submissionDate": "",
     "publicReleaseDate": "",
     "ontologySourceReferences": [],

--- a/test-data/biosamples-input-isa.json
+++ b/test-data/biosamples-input-isa.json
@@ -277,7 +277,7 @@
                     "@id": "#characteristic_category/collection_date_323"
                   },
                   "value": {
-                    "annotationValue": "01/01/2022",
+                    "annotationValue": "2022-01-01",
                     "termSource": "",
                     "termAccession": ""
                   }


### PR DESCRIPTION
- Updated `repository-services/docker-compose.yml` to build from the `MARS` repo root, so the same Dockerfiles work both in this repo and in downstream CI setups.
- Fixed BioSamples sample creation so the derived sample is no longer built by copying all source metadata. Instead, it now starts from `sample.characteristics`, while shared identity fields such as `organism` and `tax_id` are synchronized between source and sample, and source-only context fields such as `collection date` and `geographic location (country and/or sea)` are propagated only from source to sample when needed.
- Switched BioSamples attribute-key resolution to use the study-level ISA `characteristicCategories` mapping (`category @id -> characteristicType.annotationValue`) for both source and sample characteristics. This avoids relying on characteristic ids as field names, since those ids are not guaranteed to be human-readable or semantically stable and may simply be arbitrary internal identifiers. It also removes the need to derive underscored field names from ids, because the semantic ISA label is used directly as the attribute key.
- Updated ENA BioSamples accession lookup to use the study-level ISA characteristic mapping as well, so accession detection is based on the semantic `accession` label rather than depending on raw characteristic id patterns.
- ENA experiment submission now uses the study sample BioSamples accession by default, throwing an error if no samples with a BioSamples Accession are present on study level
- Updated the example ISA test data with an ENA-valid investigation title and description for submission tests.